### PR TITLE
Use LE transport for GATT connections on API 23+

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/GattConnection.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/GattConnection.kt
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager
 import android.util.Log
 import androidx.core.app.ActivityCompat
 import android.Manifest
+import android.os.Build
 import com.remoticom.streetlighting.services.bluetooth.gatt.bdc.bdcServiceMatchingMask
 import com.remoticom.streetlighting.services.bluetooth.gatt.bdc.getBdcCharacteristic
 import com.remoticom.streetlighting.services.bluetooth.gatt.zsc010.getZsc010Characteristic
@@ -60,7 +61,11 @@ class GattConnection(
     }
 
     try {
-      gatt = device.connectGatt(context, autoConnect, this)
+      gatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        device.connectGatt(context, autoConnect, this, BluetoothDevice.TRANSPORT_LE)
+      } else {
+        device.connectGatt(context, autoConnect, this)
+      }
       macAddress = null
     } catch (securityException: SecurityException) {
       Log.e(TAG, "SecurityException during connectGatt", securityException)


### PR DESCRIPTION
## Summary
- Add Build version check in `GattConnection.connectGatt` to use `BluetoothDevice.TRANSPORT_LE` on Android M and above

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c42f6e87b483278c3562837ec98a98