### PR TITLE
Handle missing Bluetooth permission during GATT connection

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/MainActivity.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/MainActivity.kt
@@ -23,13 +23,14 @@ import androidx.navigation.ui.*
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.remoticom.streetlighting.services.authentication.AuthenticationService
 import com.remoticom.streetlighting.utilities.checkBluetoothEnabled
+import com.remoticom.streetlighting.utilities.BluetoothPermissionProvider
 import com.remoticom.streetlighting.ui.login.LoginViewModel
 import com.remoticom.streetlighting.utilities.InjectorUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 
-class MainActivity : AppCompatActivity(), CoroutineScopeProvider {
+class MainActivity : AppCompatActivity(), CoroutineScopeProvider, BluetoothPermissionProvider {
 
   companion object {
     private const val TAG = "MainActivity"
@@ -249,6 +250,7 @@ class MainActivity : AppCompatActivity(), CoroutineScopeProvider {
         )
       }
     } else {
+      bluetoothPermissionsGranted = true
       Log.d(TAG, "No need to request BLUETOOTH_SCAN and BLUETOOTH_CONNECT permissions on Android version ${Build.VERSION.SDK_INT}")
     }
   }
@@ -294,6 +296,14 @@ class MainActivity : AppCompatActivity(), CoroutineScopeProvider {
     } else {
       Log.d(TAG, "Location permission is/was granted. Not requesting permission.")
     }
+  }
+
+  override fun areBluetoothPermissionsGranted(): Boolean {
+    return bluetoothPermissionsGranted
+  }
+
+  override fun requestBluetoothPermissions() {
+    showBluetoothPermissionDialog()
   }
 
   override fun provideScope(): CoroutineScope {

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/utilities/BluetoothPermissionProvider.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/utilities/BluetoothPermissionProvider.kt
@@ -1,0 +1,6 @@
+package com.remoticom.streetlighting.utilities
+
+interface BluetoothPermissionProvider {
+  fun areBluetoothPermissionsGranted(): Boolean
+  fun requestBluetoothPermissions()
+}


### PR DESCRIPTION
## Summary
- expose bluetooth permission status from `MainActivity`
- verify bluetooth permissions before attempting GATT connection and prompt user if missing
- surface missing-permission errors to UI so permission dialog can be shown again

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c7c3b760f4832793207661a97f973d