### PR TITLE
Handle MTU and chunked characteristic writes

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/bdc/operations/BdcWriteCharacteristicGattOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/bdc/operations/BdcWriteCharacteristicGattOperation.kt
@@ -35,7 +35,12 @@ open class BdcWriteCharacteristicGattOperation<T>(
       return
     }
 
-    if (!connection.writeCharacteristic(bluetoothCharacteristic)) {
+    val bytes = bluetoothCharacteristic.value ?: run {
+      completeWithError(GattErrorCode.SerializationFailed)
+      return
+    }
+
+    if (!connection.writeValueChunked(bluetoothCharacteristic, bytes)) {
       completeWithError(GattErrorCode.GattMethodFailed)
       return
     }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/Sno110ReadSchedulerScheduleEntriesOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/Sno110ReadSchedulerScheduleEntriesOperation.kt
@@ -32,7 +32,12 @@ open class Sno110ReadSchedulerScheduleEntriesOperation() : GattOperation<List<Sc
       return
     }
 
-    if (!connection.writeCharacteristic(bluetoothCharacteristic)) {
+    val bytes = bluetoothCharacteristic.value ?: run {
+      completeWithError(GattErrorCode.SerializationFailed)
+      return
+    }
+
+    if (!connection.writeValueChunked(bluetoothCharacteristic, bytes)) {
       completeWithError(GattErrorCode.GattMethodFailed)
       return
     }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/Sno110WriteCharacteristicGattOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/Sno110WriteCharacteristicGattOperation.kt
@@ -36,7 +36,12 @@ open class Sno110WriteCharacteristicGattOperation<T>(
       return
     }
 
-    if (!connection.writeCharacteristic(bluetoothCharacteristic)) {
+    val bytes = bluetoothCharacteristic.value ?: run {
+      completeWithError(GattErrorCode.SerializationFailed)
+      return
+    }
+
+    if (!connection.writeValueChunked(bluetoothCharacteristic, bytes)) {
       completeWithError(GattErrorCode.GattMethodFailed)
       return
     }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/authentication/Sno110WriteChallengeOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/authentication/Sno110WriteChallengeOperation.kt
@@ -37,7 +37,12 @@ open class Sno110WriteChallengeOperation<T>(
       return
     }
 
-    if (!connection.writeCharacteristic(bluetoothCharacteristic)) {
+    val bytes = bluetoothCharacteristic.value ?: run {
+      completeWithError(GattErrorCode.SerializationFailed)
+      return
+    }
+
+    if (!connection.writeValueChunked(bluetoothCharacteristic, bytes)) {
       completeWithError(GattErrorCode.GattMethodFailed)
       return
     }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/authentication/Sno110WriteTokenOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/sno110/operations/authentication/Sno110WriteTokenOperation.kt
@@ -36,7 +36,12 @@ open class Sno110WriteTokenOperation(
       return
     }
 
-    if (!connection.writeCharacteristic(bluetoothCharacteristic)) {
+    val bytes = bluetoothCharacteristic.value ?: run {
+      completeWithError(GattErrorCode.SerializationFailed)
+      return
+    }
+
+    if (!connection.writeValueChunked(bluetoothCharacteristic, bytes)) {
       completeWithError(GattErrorCode.GattMethodFailed)
       return
     }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/zsc010/operations/Zsc010WriteCharacteristicGattOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/zsc010/operations/Zsc010WriteCharacteristicGattOperation.kt
@@ -35,7 +35,12 @@ open class Zsc010WriteCharacteristicGattOperation<T>(
       return
     }
 
-    if (!connection.writeCharacteristic(bluetoothCharacteristic)) {
+    val bytes = bluetoothCharacteristic.value ?: run {
+      completeWithError(GattErrorCode.SerializationFailed)
+      return
+    }
+
+    if (!connection.writeValueChunked(bluetoothCharacteristic, bytes)) {
       completeWithError(GattErrorCode.GattMethodFailed)
       return
     }


### PR DESCRIPTION
## Summary
- track negotiated MTU on `GattConnection` and warn if it's too small
- add `writeValueChunked` to split large characteristic writes across MTU-sized chunks
- use chunked writes for all characteristic writers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c7d6b584ec8327ba0df0e14176e0c1