### PR TITLE
Avoid disconnecting active node when starting scan

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/data/NodeRepository.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/data/NodeRepository.kt
@@ -208,7 +208,9 @@ class NodeRepository private constructor (
   }
 
   suspend fun startScan() {
-    connectionService.disconnect()
+    if (_state.value?.connectedNode == null) {
+      connectionService.disconnect()
+    }
     scannerService.startScan()
   }
 

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/NodeListViewModel.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/NodeListViewModel.kt
@@ -69,6 +69,13 @@ class NodeListViewModel(private val nodeRepository: NodeRepository) :
       return
     }
 
+    val connectionStatus = nodeRepository.state.value?.connectionStatus
+    if (connectionStatus != null && connectionStatus != NodeConnectionStatus.DISCONNECTED) {
+      Log.i(TAG, "Connection active. Not starting scan.")
+
+      return
+    }
+
     isTimeout = false
 
     // Make it easier to recover from issues, like peripherals that were not loaded


### PR DESCRIPTION
## Summary
- Guard NodeRepository's `startScan` so an active connection isn't dropped
- Skip launching scans from NodeListViewModel when a connection is active

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c81090e6b88327b9925dc224ff4a2c