### PR TITLE
Prevent premature disconnect in NodeRepository

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/data/NodeRepository.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/data/NodeRepository.kt
@@ -49,11 +49,11 @@ class NodeRepository private constructor (
     }
   }
 
-  @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-  private fun onPause() {
+  @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+  private fun onDestroy() {
     _state.value?.connectedNode?.let {
       runBlocking {
-        Log.d(TAG, "Application on pause. Disconnecting if needed...")
+        Log.d(TAG, "Application destroyed. Disconnecting if needed...")
         disconnectNode(it)
       }
     }


### PR DESCRIPTION
## Summary
- avoid disconnecting BLE connection when activity stops; only disconnect on destroy

## Testing
- `./gradlew test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_b_68c81259e1248327a785c4aca51091f1