### PR TITLE
Log detailed GATT disconnect information

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
@@ -486,6 +486,18 @@ class GattConnectionService constructor(
       newState: Int
     ) {
       super.onConnectionStateChange(gatt, status, newState)
+      val stateDescription = when (newState) {
+        BluetoothProfile.STATE_DISCONNECTED -> "DISCONNECTED"
+        BluetoothProfile.STATE_CONNECTING -> "CONNECTING"
+        BluetoothProfile.STATE_CONNECTED -> "CONNECTED"
+        BluetoothProfile.STATE_DISCONNECTING -> "DISCONNECTING"
+        else -> "UNKNOWN"
+      }
+
+      Log.d(
+        TAG,
+        "onConnectionStateChange address=${gatt.device.address}, status=${status.toGattStatusDescription()}, newState=$stateDescription ($newState)"
+      )
 
       val connectionState: GattConnectionStatus? = when (newState) {
         BluetoothProfile.STATE_DISCONNECTED -> GattConnectionStatus.Disconnected


### PR DESCRIPTION
## Summary
- Log connection status, state and device address on GATT state changes using human-readable codes

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `adb logcat -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c8228057548327914b3b04154454c1