### PR TITLE
Improve keep-alive job scheduling and visibility

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
@@ -62,11 +62,19 @@ class GattConnectionService constructor(
 
   private fun startKeepAlive() {
     keepAliveJob?.cancel()
-    keepAliveJob = scope.launch {
+    keepAliveJob = scope.launch(Dispatchers.IO + SupervisorJob()) {
+      try {
+        Log.d(TAG, "Keep-alive initial ping")
+        currentOperationsService().readDiagnosticsCharacteristics(null, null)
+      } catch (e: Exception) {
+        Log.w(TAG, "Keep-alive initial ping failed", e)
+      }
       while (isActive) {
         delay(keepAliveInterval)
+        Log.d(TAG, "Keep-alive ping")
         try {
           currentOperationsService().readDiagnosticsCharacteristics(null, null)
+          Log.d(TAG, "Keep-alive ping successful")
         } catch (e: Exception) {
           Log.w(TAG, "Keep-alive read failed", e)
         }


### PR DESCRIPTION
## Summary
- run keep-alive loop on Dispatchers.IO with a SupervisorJob
- send the first ping immediately and log each iteration

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c827f675988327afca09b26df7467a