### PR TITLE
Reset GATT operations when disconnected

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
@@ -540,7 +540,10 @@ class GattConnectionService constructor(
 
       when (connectionState) {
         GattConnectionStatus.Connected -> startKeepAlive()
-        GattConnectionStatus.Disconnected -> stopKeepAlive()
+        GattConnectionStatus.Disconnected -> {
+          currentConnection?.resetOperation()
+          stopKeepAlive()
+        }
         else -> {}
       }
     }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/GattConnection.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/GattConnection.kt
@@ -269,6 +269,12 @@ class GattConnection(
     Log.v(TAG, "onConnectionStateChange called")
     super.onConnectionStateChange(gatt, status, newState)
 
+    val activeOperation = currentOperation
+
+    if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+      resetOperation()
+    }
+
     if (BluetoothGatt.GATT_SUCCESS == status) {
       when (newState) {
          BluetoothProfile.STATE_DISCONNECTED -> {
@@ -285,7 +291,7 @@ class GattConnection(
 
     // Must be called last, because code after suspended operation
     // must see changes by made by callback
-    currentOperation?.onConnectionStateChange(gatt, status, newState)
+    activeOperation?.onConnectionStateChange(gatt, status, newState)
   }
 
   override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {


### PR DESCRIPTION
## Summary
- reset the current GATT operation when a device disconnects before the client closes the connection
- make the service callback clear in-flight operations when a disconnection is reported

## Testing
- sh gradlew lint --console=plain *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c919bcc4848327af110609b7cec61c