### PR TITLE
Add write-in-progress handling to node settings

### DIFF
--- a/bledalicontroller/app/src/main/res/layout/fragment_node_settings.xml
+++ b/bledalicontroller/app/src/main/res/layout/fragment_node_settings.xml
@@ -6,6 +6,7 @@
   <data>
 
     <import type="android.view.View"/>
+    <import type="com.remoticom.streetlighting.data.NodeConnectionStatus"/>
 
     <variable
       name="viewmodel"
@@ -433,8 +434,17 @@
           android:layout_height="@dimen/button_big_height"
           android:layout_gravity="bottom"
           android:text="@string/node_settings_write_button_text"
-          app:enabledWhenConnected="@{viewmodel.state.connectionStatus}"
+          android:enabled="@{!viewmodel.state.isWriting && viewmodel.state.connectionStatus == NodeConnectionStatus.CONNECTED}"
           android:onClick="@{writeNodeClickListener}"/>
+
+        <ProgressBar
+          android:id="@+id/node_settings_progress_writing"
+          style="?android:attr/progressBarStyleSmall"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:layout_marginTop="8dp"
+          android:visibility="@{viewmodel.state.isWriting ? View.VISIBLE : View.GONE}" />
 
       </LinearLayout>
 

--- a/bledalicontroller/app/src/main/res/layout/fragment_node_settings.xml
+++ b/bledalicontroller/app/src/main/res/layout/fragment_node_settings.xml
@@ -434,7 +434,7 @@
           android:layout_height="@dimen/button_big_height"
           android:layout_gravity="bottom"
           android:text="@string/node_settings_write_button_text"
-          android:enabled="@{!viewmodel.state.isWriting && viewmodel.state.connectionStatus == NodeConnectionStatus.CONNECTED}"
+          android:enabled="@{!viewmodel.state.isWriting &amp;&amp; viewmodel.state.connectionStatus == NodeConnectionStatus.CONNECTED}"
           android:onClick="@{writeNodeClickListener}"/>
 
         <ProgressBar


### PR DESCRIPTION
## Summary
- extend `NodeSettingsViewModel` state with an `isWriting` flag and guard updates while a write is in progress
- expose the write-in-progress flag to data binding and disable the write button during operations
- add a small progress indicator to the node settings screen to reflect active write operations

## Testing
- `./gradlew --console=plain :app:compileDevelopmentDebugKotlin` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9278dc1d48327829f1050bbbbd0a8