### PR TITLE
Use process lifecycle for node repository observers

### DIFF
--- a/bledalicontroller/app/build.gradle
+++ b/bledalicontroller/app/build.gradle
@@ -94,6 +94,7 @@ dependencies {
   // implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
   implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
   implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+  implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
   implementation "androidx.webkit:webkit:1.12.1"
 
   implementation 'androidx.recyclerview:recyclerview:1.3.2'

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/NodeListFragment.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/NodeListFragment.kt
@@ -12,7 +12,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.findNavController
@@ -39,8 +38,7 @@ class NodeListFragment : Fragment() {
   private val viewModel: NodeListViewModel by viewModels {
     InjectorUtils.provideNodeListViewModelFactory(
       requireContext(),
-      this.activity as CoroutineScopeProvider,
-      this.activity as FragmentActivity
+      this.activity as CoroutineScopeProvider
     )
   }
 

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/dimplan/NodeDimPlanListFragment.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/dimplan/NodeDimPlanListFragment.kt
@@ -5,7 +5,6 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
@@ -49,7 +48,6 @@ class NodeDimPlanListFragment : Fragment() {
     InjectorUtils.provideNodeSettingsViewModelFactory(
       requireContext(),
       this.activity as CoroutineScopeProvider,
-      this.activity as FragmentActivity,
       args.nodeId
     )
   }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/dimplan/settings/NodeDimPlanSettingsFragment.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/dimplan/settings/NodeDimPlanSettingsFragment.kt
@@ -5,7 +5,6 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.navArgs
@@ -31,7 +30,6 @@ class NodeDimPlanSettingsFragment : Fragment() {
     InjectorUtils.provideNodeSettingsViewModelFactory(
       requireContext(),
       this.activity as CoroutineScopeProvider,
-      this.activity as FragmentActivity,
       args.nodeId
     )
   }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/info/NodeInfoListFragment.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/info/NodeInfoListFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.*
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
@@ -97,7 +96,6 @@ class NodeInfoListFragment : Fragment() {
     InjectorUtils.provideNodeInfoListViewModelFactory(
       requireContext(),
       this.activity as CoroutineScopeProvider,
-      this.activity as FragmentActivity,
       args.nodeId
     )
   }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/settings/NodeSettingsFragment.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/settings/NodeSettingsFragment.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import android.view.*
 import android.widget.*
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
@@ -62,7 +61,6 @@ class NodeSettingsFragment : Fragment() {
     InjectorUtils.provideNodeSettingsViewModelFactory(
       requireContext(),
       this.activity as CoroutineScopeProvider,
-      this.activity as FragmentActivity,
       args.nodeId
     )
   }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/settings/write/NodeWriteConfirmationFragment.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/ui/nodes/settings/write/NodeWriteConfirmationFragment.kt
@@ -5,7 +5,6 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -23,7 +22,6 @@ class NodeWriteConfirmationFragment : Fragment() {
     InjectorUtils.provideNodeWriteConfirmationViewModelFactory(
       requireContext(),
       this.activity as CoroutineScopeProvider,
-      this.activity as FragmentActivity,
       args.nodeId,
       args.success
     )

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/utilities/InjectorUtils.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/utilities/InjectorUtils.kt
@@ -1,7 +1,7 @@
 package com.remoticom.streetlighting.utilities
 
 import android.content.Context
-import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.remoticom.streetlighting.data.NodeRepository
 // import com.remoticom.streetlighting.services.bluetooth.gatt.MockConnectionService
 // import com.remoticom.streetlighting.services.bluetooth.scanner.MockScannerService
@@ -19,8 +19,10 @@ import com.remoticom.streetlighting.ui.login.LoginViewModelFactory
 object InjectorUtils {
 
   var currentNodeSettingsViewModelFactory : NodeSettingsViewModelFactory? = null
+  @Volatile
+  private var isNodeRepositoryLifecycleObserverRegistered = false
 
-  fun getNodeRepository(context: Context, scopeProvider: CoroutineScopeProvider, lifecycleOwner: LifecycleOwner): NodeRepository {
+  fun getNodeRepository(context: Context, scopeProvider: CoroutineScopeProvider): NodeRepository {
     val scope = scopeProvider.provideScope()
     val scannerService = BluetoothScannerService.getInstance(context = context)
 
@@ -33,42 +35,46 @@ object InjectorUtils {
 
     val nodeRepository = NodeRepository.getInstance(scannerService, connectionService)
 
-    // TODO (REFACTOR): Do we need to call removeObserver(), and if so: when?
-    lifecycleOwner.lifecycle.addObserver(nodeRepository)
+    if (!isNodeRepositoryLifecycleObserverRegistered) {
+      synchronized(this) {
+        if (!isNodeRepositoryLifecycleObserverRegistered) {
+          // Ensure the repository observes the application's lifecycle rather than fragment lifecycles.
+          ProcessLifecycleOwner.get().lifecycle.addObserver(nodeRepository)
+          isNodeRepositoryLifecycleObserverRegistered = true
+        }
+      }
+    }
 
     return nodeRepository
   }
 
   fun provideNodeListViewModelFactory(
     context: Context,
-    scopeProvider: CoroutineScopeProvider,
-    lifecycleOwner: LifecycleOwner
+    scopeProvider: CoroutineScopeProvider
   ): NodeListViewModelFactory {
-    val repository = getNodeRepository(context, scopeProvider, lifecycleOwner)
+    val repository = getNodeRepository(context, scopeProvider)
     return NodeListViewModelFactory(repository)
   }
 
   fun provideNodeInfoListViewModelFactory(
     context: Context,
     scopeProvider: CoroutineScopeProvider,
-    lifecycleOwner: LifecycleOwner,
     nodeId: String
   ): NodeInfoListViewModelFactory {
-    val repository = getNodeRepository(context, scopeProvider, lifecycleOwner)
+    val repository = getNodeRepository(context, scopeProvider)
     return NodeInfoListViewModelFactory(repository, nodeId)
   }
 
   fun provideNodeSettingsViewModelFactory(
     context: Context,
     scopeProvider: CoroutineScopeProvider,
-    lifecycleOwner: LifecycleOwner,
     nodeId: String
   ): NodeSettingsViewModelFactory {
     currentNodeSettingsViewModelFactory?.let {
       return it
     }
 
-    val repository = getNodeRepository(context, scopeProvider, lifecycleOwner)
+    val repository = getNodeRepository(context, scopeProvider)
     currentNodeSettingsViewModelFactory = NodeSettingsViewModelFactory(repository, nodeId)
 
     return currentNodeSettingsViewModelFactory!!
@@ -82,11 +88,10 @@ object InjectorUtils {
   fun provideNodeWriteConfirmationViewModelFactory(
     context: Context,
     scopeProvider: CoroutineScopeProvider,
-    lifecycleOwner: LifecycleOwner,
     nodeId: String,
     success: Boolean
   ): NodeWriteConfirmationViewModelFactory {
-    val repository = getNodeRepository(context, scopeProvider, lifecycleOwner)
+    val repository = getNodeRepository(context, scopeProvider)
     return NodeWriteConfirmationViewModelFactory(repository, nodeId, success)
   }
 


### PR DESCRIPTION
## Summary
- register `NodeRepository` with the process lifecycle so it only observes a single application-level owner
- remove fragment lifecycle arguments when providing node-related ViewModel factories
- add the lifecycle-process dependency so `ProcessLifecycleOwner` is available

## Testing
- `bash gradlew --console=plain :app:assembleDebug --info` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c938214ea48327ab47b7680925c765