### PR TITLE
Handle failed BDC connection prerequisites

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/GattConnectionService.kt
@@ -305,11 +305,15 @@ class GattConnectionService constructor(
       )
 
       val operationsService = currentOperationsService()
-      operationsService.connect(
+      val connectAttemptStarted = operationsService.connect(
         device,
         tokenProvider,
         peripheral
       )
+
+      if (!connectAttemptStarted) {
+        continue
+      }
     }
 
     if (!isConnected) {

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/OperationsService.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/OperationsService.kt
@@ -7,7 +7,7 @@ import com.remoticom.streetlighting.services.web.data.Peripheral
 
 interface OperationsService {
 
-  suspend fun connect(device: Device, tokenProvider: TokenProvider, peripheral: Peripheral?)
+  suspend fun connect(device: Device, tokenProvider: TokenProvider, peripheral: Peripheral?): Boolean
 
   suspend fun disconnect()
 

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/bdc/BdcOperationsService.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/bdc/BdcOperationsService.kt
@@ -21,38 +21,39 @@ class BdcOperationsService constructor(
     device: Device,
     tokenProvider: TokenProvider,
     peripheral: Peripheral?
-  ) {
-    peripheral ?: return
-
-    if (null == peripheral.password) {
-      Log.e(TAG, "Password not yet available")
-
-      return
+  ): Boolean {
+    val nonNullPeripheral = peripheral ?: run {
+      Log.e(TAG, "Peripheral not available")
+      return false
     }
 
-    val devicePassword = peripheral.password.toUIntOrNull()?.toInt()
+    val password = nonNullPeripheral.password ?: run {
+      Log.e(TAG, "Password not yet available")
 
-    if (null == devicePassword) {
+      return false
+    }
+
+    val devicePassword = password.toUIntOrNull()?.toInt() ?: run {
       Log.e(TAG, "Password has invalid format")
 
-      return
+      return false
     }
 
     // Connect
     if (!connectionProvider.performOperation(ConnectGattOperation(), false)) {
-      return
+      return false
     }
 
     // Request MTU
     if (!connectionProvider.performOperation(RequestMtuOperation(517), false)) {
       connectionProvider.tearDown()
-      return
+      return false
     }
 
     // Discover services
     if (!connectionProvider.performOperation(DiscoverServicesOperation(), false)) {
       connectionProvider.tearDown()
-      return
+      return false
     }
 
     delay(500)
@@ -60,10 +61,12 @@ class BdcOperationsService constructor(
     // Write pin
     if (connectionProvider.performOperation(BdcWriteSecurityPasswordOperation(devicePassword)) != devicePassword) {
       connectionProvider.tearDown()
-      return
+      return false
     }
 
     delay(500)
+
+    return true
   }
 
   override suspend fun readGeneralCharacteristics() : GeneralCharacteristics {

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/zsc010/Zsc010OperationsService.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/zsc010/Zsc010OperationsService.kt
@@ -18,39 +18,39 @@ class Zsc010OperationsService constructor(
     device: Device,
     tokenProvider: TokenProvider,
     peripheral: Peripheral?
-  ) {
-    peripheral ?: return
+  ): Boolean {
+    val nonNullPeripheral = peripheral ?: return false
 
-    if (null == peripheral.password) {
+    val password = nonNullPeripheral.password ?: run {
       Log.e(TAG, "Password not yet available")
 
-      return
+      return false
     }
 
-    val devicePassword = peripheral.password.toUIntOrNull()?.toInt()
-
-    if (null == devicePassword) {
+    val devicePassword = password.toUIntOrNull()?.toInt() ?: run {
       Log.e(TAG, "Password has invalid format")
 
-      return
+      return false
     }
 
     // Connect
     if (!connectionProvider.performOperation(ConnectGattOperation(), false)) {
-      return
+      return false
     }
 
     // Discover services
     if (!connectionProvider.performOperation(DiscoverServicesOperation(), false)) {
       connectionProvider.tearDown()
-      return
+      return false
     }
 
     // Write pin
     if (connectionProvider.performOperation(Zsc010WriteSecurityPasswordOperation(devicePassword)) != devicePassword) {
       connectionProvider.tearDown()
-      return
+      return false
     }
+
+    return true
   }
 
   override suspend fun readGeneralCharacteristics() : GeneralCharacteristics {


### PR DESCRIPTION
## Summary
- make OperationsService.connect return a boolean so callers can detect when no attempt was made
- return false and log errors for missing BDC credentials while keeping other operation services aligned
- have the connection retry loop skip delays only once a connection attempt actually started

## Testing
- `./gradlew :app:lint` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c951c05cec83279b36a3294e80b43a