### PR TITLE
Handle connecting nodes without characteristics

### DIFF
--- a/bledalicontroller/app/build.gradle
+++ b/bledalicontroller/app/build.gradle
@@ -115,6 +115,7 @@ dependencies {
   implementation 'com.microsoft.identity.client:msal:3.0.2'
 
   testImplementation 'junit:junit:4.13.2'
+  testImplementation 'androidx.arch.core:core-testing:2.2.0'
   androidTestImplementation 'androidx.test.ext:junit:1.2.1'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/data/NodeRepository.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/data/NodeRepository.kt
@@ -107,7 +107,11 @@ class NodeRepository private constructor (
     val (connectionStatus, connectedDevice, characteristics, lastGattError) = connectionState.value!!
     val (peripherals) = webState.value!!
 
-    val nodeConnectionStatus = connectionStatus.toNodeConnectionStatus()
+    val nodeConnectionStatus = when {
+      connectionStatus == GattConnectionStatus.Connected && characteristics == null ->
+        NodeConnectionStatus.CONNECTING
+      else -> connectionStatus.toNodeConnectionStatus()
+    }
 
     val connectedNode = connectedDevice?.let {
       results[it.uuid]?.let { result ->
@@ -150,11 +154,13 @@ class NodeRepository private constructor (
       }
     }
 
+    val stateConnectionStatus = connectedNode?.connectionStatus ?: nodeConnectionStatus
+
     return State(
       isScanning = isScanning,
       scanResults = scanResults,
       scanErrorCode = errorCode,
-      connectionStatus = nodeConnectionStatus,
+      connectionStatus = stateConnectionStatus,
       connectedNode = connectedNode,
       lastConnectionError = lastGattError?.toNodeConnectionError(),
       hasTimedOutWithoutResults = hasTimedOutWithoutResults

--- a/bledalicontroller/app/src/test/java/com/remoticom/streetlighting/data/NodeRepositoryTest.kt
+++ b/bledalicontroller/app/src/test/java/com/remoticom/streetlighting/data/NodeRepositoryTest.kt
@@ -1,0 +1,110 @@
+package com.remoticom.streetlighting.data
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.remoticom.streetlighting.services.bluetooth.data.Device
+import com.remoticom.streetlighting.services.bluetooth.data.DeviceScanInfo
+import com.remoticom.streetlighting.services.bluetooth.data.DeviceType
+import com.remoticom.streetlighting.services.bluetooth.data.characteristics.DeviceCharacteristics
+import com.remoticom.streetlighting.services.bluetooth.gatt.ConnectionService
+import com.remoticom.streetlighting.services.bluetooth.gatt.connection.GattConnectionStatus
+import com.remoticom.streetlighting.services.bluetooth.scanner.ScannerService
+import com.remoticom.streetlighting.services.web.TokenProvider
+import com.remoticom.streetlighting.services.web.data.Peripheral
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class NodeRepositoryTest {
+
+  @get:Rule
+  val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+  @Test
+  fun `connected without characteristics is treated as connecting`() {
+    val device = TestDevice(uuid = "test-uuid", address = "00:11:22:33:44:55")
+    val scannerState = MutableLiveData(ScannerService.State())
+    val connectionState = MutableLiveData(ConnectionService.State())
+
+    val repository = createRepository(scannerState, connectionState)
+
+    scannerState.value = ScannerService.State(
+      results = mapOf(device.uuid to DeviceScanInfo(device, rssi = -42))
+    )
+
+    connectionState.value = ConnectionService.State(
+      connectionStatus = GattConnectionStatus.Connected,
+      device = device,
+      characteristics = null,
+      lastGattError = null
+    )
+
+    val state = repository.state.value
+
+    requireNotNull(state)
+    assertEquals(NodeConnectionStatus.CONNECTING, state.connectionStatus)
+    assertEquals(NodeConnectionStatus.CONNECTING, state.connectedNode?.connectionStatus)
+  }
+
+  private fun createRepository(
+    scannerLiveData: MutableLiveData<ScannerService.State>,
+    connectionLiveData: MutableLiveData<ConnectionService.State>
+  ): NodeRepository {
+    val constructor = NodeRepository::class.java.getDeclaredConstructor(
+      ScannerService::class.java,
+      ConnectionService::class.java
+    )
+    constructor.isAccessible = true
+
+    return constructor.newInstance(
+      FakeScannerService(scannerLiveData),
+      FakeConnectionService(connectionLiveData)
+    )
+  }
+
+  private class FakeScannerService(
+    private val liveData: MutableLiveData<ScannerService.State>
+  ) : ScannerService {
+    override val state = liveData
+
+    override fun startScan() = Unit
+
+    override fun stopScan(isTimeout: Boolean) = Unit
+  }
+
+  private class FakeConnectionService(
+    private val liveData: MutableLiveData<ConnectionService.State>
+  ) : ConnectionService {
+    override val state = liveData
+
+    override suspend fun connect(
+      device: Device,
+      tokenProvider: TokenProvider,
+      peripheral: Peripheral?
+    ): Boolean = false
+
+    override suspend fun readCharacteristics(health: Int?, state: Int?) =
+      throw UnsupportedOperationException("Not required for test")
+
+    override suspend fun writeCharacteristics(characteristics: DeviceCharacteristics) =
+      throw UnsupportedOperationException("Not required for test")
+
+    override suspend fun readDaliBanks() =
+      throw UnsupportedOperationException("Not required for test")
+
+    override suspend fun disconnect() =
+      throw UnsupportedOperationException("Not required for test")
+
+    override fun isOperationInProgress(): Boolean = false
+  }
+
+  private data class TestDevice(
+    override val uuid: String,
+    override val address: String,
+    override val type: DeviceType = DeviceType.Zsc010,
+    override val name: String? = null,
+    override val serviceUuids: List<android.os.ParcelUuid>? = null,
+    override val health: Int? = null,
+    override val state: Int? = null
+  ) : Device
+}

--- a/bledalicontroller/app/src/test/java/com/remoticom/streetlighting/utilities/BindingAdaptersTest.kt
+++ b/bledalicontroller/app/src/test/java/com/remoticom/streetlighting/utilities/BindingAdaptersTest.kt
@@ -1,0 +1,25 @@
+package com.remoticom.streetlighting.utilities
+
+import android.test.mock.MockContext
+import android.view.View
+import com.remoticom.streetlighting.data.NodeConnectionStatus
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BindingAdaptersTest {
+
+  @Test
+  fun `enabledWhenConnected disables view until node is connected`() {
+    val view = TestView()
+    view.isEnabled = true
+
+    enabledWhenConnected(view, NodeConnectionStatus.CONNECTING)
+    assertFalse(view.isEnabled)
+
+    enabledWhenConnected(view, NodeConnectionStatus.CONNECTED)
+    assertTrue(view.isEnabled)
+  }
+
+  private class TestView : View(MockContext())
+}


### PR DESCRIPTION
## Summary
- treat connections that have not loaded characteristics as still connecting
- propagate the adjusted status to repository state so the UI waits for readiness
- add unit tests covering the repository merge behaviour and the binding adapter, plus bring in the core-testing helper

## Testing
- ./gradlew testDevelopmentDebugUnitTest *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c96c32b0008327a1fa163190340945