### PR TITLE
Handle disconnect errors for GATT operations

### DIFF
--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/ConnectGattOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/ConnectGattOperation.kt
@@ -34,5 +34,7 @@ class ConnectGattOperation : GattOperation<Boolean>() {
       completeWithError(GattErrorCode.GattError, status)
     }
   }
+
+  override fun shouldFailOnDisconnect(): Boolean = false
 }
 

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/DisconnectGattOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/DisconnectGattOperation.kt
@@ -32,4 +32,6 @@ class DisconnectGattOperation() : GattOperation<Boolean>() {
     }
 
   }
+
+  override fun shouldFailOnDisconnect(): Boolean = false
 }

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/DiscoverServicesGattOperation.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/DiscoverServicesGattOperation.kt
@@ -52,5 +52,7 @@ class DiscoverServicesOperation() : GattOperation<Boolean>() {
   companion object {
     private const val TAG = "DiscoverServicesOp"
   }
+
+  override fun shouldFailOnDisconnect(): Boolean = false
 }
 

--- a/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/GattConnection.kt
+++ b/bledalicontroller/app/src/main/java/com/remoticom/streetlighting/services/bluetooth/gatt/connection/GattConnection.kt
@@ -271,7 +271,14 @@ class GattConnection(
 
     val activeOperation = currentOperation
 
-    if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+    val shouldCompleteOperation =
+      status != BluetoothGatt.GATT_SUCCESS || newState == BluetoothProfile.STATE_DISCONNECTED
+
+    if (shouldCompleteOperation) {
+      (activeOperation as? GattOperation<*>)?.handleConnectionStateChange(status, newState)
+    }
+
+    if (newState == BluetoothProfile.STATE_DISCONNECTED || status != BluetoothGatt.GATT_SUCCESS) {
       resetOperation()
     }
 


### PR DESCRIPTION
## Summary
- ensure active GATT operations fail fast when the link drops or reports a non-success status so the mutex can unlock cleanly
- guard callback delivery in `GattOperation` and allow specific operations to ignore expected disconnects
- update connection state handling to propagate disconnect failures while keeping connect/disconnect operations functional

## Testing
- `bash ./bledalicontroller/gradlew -p bledalicontroller :app:assembleDebug --console=plain --no-daemon` *(fails: Android SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca7d90926c8327a1d7d9a42d6efb2f